### PR TITLE
Fix yank leaving an empty clipboard on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.52.0",
+ "wl-clipboard-rs",
  "x11rb",
 ]
 
@@ -142,7 +143,7 @@ dependencies = [
  "crossterm",
  "directories",
  "libc",
- "quick-xml",
+ "quick-xml 0.39.2",
  "ratatui",
  "serde",
  "serde_json",
@@ -604,6 +605,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +700,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1258,6 +1271,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,6 +1415,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,6 +1497,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1558,12 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "png"
@@ -1586,6 +1635,15 @@ name = "quick-xml"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -2058,7 +2116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf",
  "phf_codegen",
 ]
@@ -2084,7 +2142,7 @@ dependencies = [
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "hex",
  "lazy_static",
  "libc",
@@ -2266,6 +2324,17 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
 
 [[package]]
 name = "tui-input"
@@ -2542,6 +2611,76 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.41.0",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -2961,6 +3100,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,9 @@ clap = { version = "4", features = ["derive"] }
 # Cross-platform clipboard for the `y` / `:y` yank commands. On Linux this
 # brings in X11/Wayland system libraries; on a headless tty `Clipboard::new`
 # returns an error which we surface as a status message.
-arboard = "3"
+# `wayland-data-control` is not a default feature of arboard 3.6+, and
+# without it Linux builds only speak X11/XWayland.
+arboard = { version = "3", features = ["wayland-data-control"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/notes/catholic-conversion.md
+++ b/notes/catholic-conversion.md
@@ -1,0 +1,74 @@
+# Catholic Version
+
+Looking to fork and extend to include deuterocanonical books.
+
+Look for Catholic Public Domain Version (CPDV)
+Pros: It provides a modern reading level. If you want your application to feel clean, contemporary, and readable without violating copyrights on translations like the RSV-2CE or NABRE, this is the only text that fits that description. The underlying XML schema structure across public codebases is typically very well-behaved.
+
+Cons: It is the work of a single individual, not a committee of theologians or linguists. Because it was independently published on the internet without a Vatican Imprimatur, serious Catholic users or academics generally do not use it for study or devotion, viewing it more as an internet novelty or developer proxy.
+
+<https://get.bible/bible-data-sets/>
+<https://github.com/scrollmapper/bible_databases_deuterocanonical>
+[Catholic Public Domain Version in USFM/PSFM format](https://github.com/BibleCorps/ENG-B-CPDV2009-pd-PSFM)
+
+## USFM vs PSFM
+
+Both **USFM** and **PSFM** are specialized, lightweight markup languages specifically designed to digitize, format, and translate scripture. They are the industry standards maintained by **UBS** (United Bible Societies) and **SIL International**.
+
+If you are looking at files inside a Bible repository, you will almost always see these formats used to manage raw text before it gets converted into HTML, JSON, or mobile apps.
+
+Here is a breakdown of what they are and how they work.
+
+---
+
+### 1. USFM (Unified Scripture Format Markup)
+
+USFM is a **tag-based text format** that looks a bit like a cross between Markdown and legacy LaTeX or HTML. It uses backward slashes (`\`) followed by a marker name to define structural elements (chapters, verses, paragraphs, poetic lines, footnotes).
+
+#### Why does it exist?
+
+Translators and developers needed a format that could be easily read and typed in a standard text editor without the massive, bloated syntax of heavy XML or JSON. Because it uses plain text, it plays incredibly well with version control systems like **Git**.
+
+#### What it looks like
+
+```usfm
+\id GEN
+\c 1
+\p
+\v 1 In the beginning God created the heaven and the earth.
+\v 2 And the earth was without form, and void;
+\q1
+\v 3 And God said, Let there be light:
+\q2 and there was light.
+
+```
+
+#### Key Markers
+
+* `\id`: The standard 3-letter book code (e.g., `GEN` for Genesis, `MAT` for Matthew, `TOB` for Tobit).
+* `\c`: Chapter number.
+* `\p`: Standard paragraph block.
+* `\v`: Verse number and text.
+* `\q1`, `\q2`: Poetic indentation levels (vital for Psalms and prophets).
+
+---
+
+### 2. PSFM (Paratext Scripture Format Markup)
+
+PSFM is a highly optimized variant of USFM used specifically by **Paratext**, the dominant software program used globally by Bible translation teams.
+
+For an application developer, **USFM and PSFM are functionally identical.** They share the same marker rules and structure. The main difference is that PSFM includes tight validation rules and strict system metadata markers specifically designed to prevent translators from making formatting mistakes during data entry.
+
+> **Developer Note:** If you download a data set and it contains `.psfm` files, you can usually rename the extension to `.usfm` or treat it identically in your parsing regex/logic.
+
+---
+
+### How to use them in your stack
+
+If you are pulling USFM/PSFM files down from a source like `Get.Bible` or a GitHub repo, you don't actually want to display them to users in their raw format. You want to parse them.
+
+You have three excellent choices for handling this data:
+
+1. **Use an existing Parser:** Do not write a regex parser from scratch if you can avoid it. The open-source ecosystem has highly robust libraries like `usfm-parser` (JavaScript/TypeScript) or Python equivalents that instantly ingest a `.usfm` file and output a perfectly structured, nested JSON object.
+2. **Convert to OSIS XML:** Many legacy web engines convert USFM into OSIS (Open Scripture Information Standard), which is a formalized XML schema that uses traditional strict tags (e.g., `<chapter id="Gen.1">`).
+3. **Direct JSON Transformation:** Most modern web apps use a build script to parse the USFM files into a local SQLite database or flat JSON structures mapped by `Book -> Chapter -> Verse` arrays, which your frontend can then dynamically query.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -103,14 +103,6 @@ fn same_chapter(a: &NavSnapshot, b: &NavSnapshot) -> bool {
         && a.chapter == b.chapter
 }
 
-/// Cross-platform clipboard write. Returns Err with a human-readable
-/// message on failure (e.g. headless tty with no DISPLAY).
-fn copy_to_clipboard(text: &str) -> std::result::Result<(), String> {
-    let mut cb = arboard::Clipboard::new().map_err(|e| e.to_string())?;
-    cb.set_text(text.to_string()).map_err(|e| e.to_string())?;
-    Ok(())
-}
-
 fn push_history(history: &mut Vec<String>, entry: &str) {
     let entry = entry.trim();
     if entry.is_empty() {
@@ -204,6 +196,15 @@ pub(crate) struct App {
 
     pub download: Option<DownloadState>,
     pub event_tx: Sender<AppEvent>,
+
+    /// Lazily-opened system clipboard used by `y` / `:y`. Kept alive for
+    /// the whole session: on X11 the clipboard contents only exist while
+    /// a `Clipboard` handle (and its request-server thread) is alive, so a
+    /// handle created and dropped per copy would empty the clipboard
+    /// before other apps could paste. `None` until the first yank (or
+    /// forever on a headless tty, where opening fails and we surface the
+    /// error as a status message instead of failing at startup).
+    pub clipboard: Option<arboard::Clipboard>,
 
     /// Set when the next render should fully repaint (terminal.clear). Used
     /// after switching translations so wide-char skip cells from the old
@@ -381,6 +382,7 @@ impl App {
             secondary_picker_cursor: 0,
             download: None,
             event_tx,
+            clipboard: None,
             needs_clear: false,
             jump_history: Vec::new(),
             jump_history_idx: None,
@@ -1284,6 +1286,20 @@ impl App {
         self.set_status(format!("unknown yank: :y {args}"));
     }
 
+    /// Cross-platform clipboard write. Returns Err with a human-readable
+    /// message on failure (e.g. headless tty with no DISPLAY). The handle
+    /// is cached in `self.clipboard` — see the field's doc comment for why
+    /// it must outlive the write (X11 ownership semantics).
+    fn copy_to_clipboard(&mut self, text: &str) -> std::result::Result<(), String> {
+        if self.clipboard.is_none() {
+            self.clipboard =
+                Some(arboard::Clipboard::new().map_err(|e| e.to_string())?);
+        }
+        let cb = self.clipboard.as_mut().expect("initialized above");
+        cb.set_text(text.to_string()).map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
     fn yank_verses(&mut self, start: u16, end: u16) {
         let Some(bible) = self.bible.as_ref() else {
             self.set_status("no translation loaded");
@@ -1323,7 +1339,7 @@ impl App {
             "{}\n\n— {} ({})",
             body, ref_label, bible.translation.display_name
         );
-        match copy_to_clipboard(&payload) {
+        match self.copy_to_clipboard(&payload) {
             Ok(()) => self.set_status(format!(
                 "copied {} ({} chars)",
                 ref_label,


### PR DESCRIPTION
## Problem

On X11, clipboard contents only persist while an `arboard::Clipboard` handle (and its request-server thread) is alive. The previous `copy_to_clipboard` helper created and dropped a fresh handle on every copy, so yanked text vanished from the system clipboard almost immediately after `y` / ` :y`.

## Changes

- `App` now holds the clipboard handle for the whole session: lazily opened on first yank (stays `None` on a headless tty, where the open failure is surfaced as a status message).
- Enabled the `wayland-data-control` arboard feature in `Cargo.toml` — it is not a default feature in arboard 3.6+, so without it Linux builds only speak X11/XWayland.

Also included: `notes/catholic-conversion.md` — research notes toward supporting the deuterocanonical books (CPDV, USFM/PSFM formats). Notes only, no code.